### PR TITLE
Adding Ctest

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,3 +18,7 @@ add_executable(pipeline
         test/main.cpp
         )
 target_include_directories(pipeline PRIVATE include)
+
+include(CTest)
+
+add_test (pipeline pipeline )


### PR DESCRIPTION
Adding Ctest.

Making typical workflow with cmake work, ie.
$ make && ctest -V